### PR TITLE
Update TinkersOCMod.java

### DIFF
--- a/src/main/java/tinkersoc/TinkersOCMod.java
+++ b/src/main/java/tinkersoc/TinkersOCMod.java
@@ -15,7 +15,7 @@ import tinkersoc.tank.DriverTinkerTank;
 import net.minecraftforge.event.entity.player.PlayerInteractEvent;
 import net.minecraft.init.Items;
 
-@Mod(modid = TinkersOCMod.MODID, name = TinkersOCMod.NAME, version = TinkersOCMod.VERSION, dependencies = "after:opencomputers@[1.7.0,);after:tconstruct@[1.12.2-2.9.0,)")
+@Mod(modid = TinkersOCMod.MODID, name = TinkersOCMod.NAME, version = TinkersOCMod.VERSION, dependencies = "required-after:opencomputers@[1.7.0,);required-after:tconstruct@[1.12.2-2.9.0,)")
 public class TinkersOCMod
 {
 


### PR DESCRIPTION
Changed "after" to "required-after" in the Dependencies string.
This will cause Forge to put up the Missing Mods screen instead of crashing with ClassNotFoundException when Tinkers or OpenComputers are not installed.